### PR TITLE
perf: no stored cache and no referral

### DIFF
--- a/public/worker.js
+++ b/public/worker.js
@@ -21,6 +21,8 @@ const sendRequest = async (target, timeout) => {
     try {
         await fetch(target, {
             mode: 'no-cors',
+            cache: 'no-store',
+            referrerPolicy: 'same-origin',
             signal: controller.signal,
         });
 


### PR DESCRIPTION
no-cache - completely ignore browser's HTTP cache. Should greatly speedup fetch requests
same-origin - hide Referer header from targets' sniff